### PR TITLE
Feat: Perform Image Float Conversion on GPU

### DIFF
--- a/src/detect_ros.py
+++ b/src/detect_ros.py
@@ -140,10 +140,8 @@ class Yolov7Publisher:
 
         # conversion to torch tensor (copied from original yolov7 repo)
         img = np_img_resized.transpose((2, 0, 1))[::-1]  # HWC to CHW, BGR to RGB
-        img = torch.from_numpy(np.ascontiguousarray(img))
-        img = img.float()  # uint8 to fp16/32
-        img /= 255  # 0 - 255 to 0.0 - 1.
-        img = img.to(self.device)
+        img = torch.from_numpy(np.ascontiguousarray(img)).to(self.device)  # stays uint8
+        img = img.float() / 255.0  # float conversion now happens on GPU
 
         # inference & rescaling the output to original img size
         detections = self.model.inference(img)


### PR DESCRIPTION
# Summary of Changes
This PR improves the YOLOv7 node performance by performing the image float comparison on the GPU instead of the CPU.

## Change Log
- Image float conversion now performed on GPU

## Link to Ticket
https://app.clickup.com/t/86c31mhuq

# Dev Testing
Tested in Dayton on CB7, CB8, and CB10 during integration testing and live loads. Performance is stable and CPU usage has dropped from 200-300% to ~15-20%.
