### PR TITLE
Fix warning yolov7-ros druing catkin_make

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ find_package(catkin REQUIRED COMPONENTS
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
 ## Generate messages in the 'msg' folder
-add_message_files(
-  FILES
-)
+# add_message_files(
+#   FILES
+# )
 
 ## Generate services in the 'srv' folder
 # add_service_files(
@@ -73,14 +73,14 @@ add_message_files(
 # )
 
 ## Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES
-  geometry_msgs
-  sensor_msgs
-  std_msgs
-  vision_msgs
-  yolov7_ros
-)
+# generate_messages(
+#   DEPENDENCIES
+#   geometry_msgs
+#   sensor_msgs
+#   std_msgs
+#   vision_msgs
+#   yolov7_ros
+# )
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##


### PR DESCRIPTION
# Summary of Changes
Fix for
```
Warnings   << yolov7_ros:cmake /home/navflex/catkin_ws/logs/yolov7_ros/build.cmake.000.log
CMake Warning at /home/navflex/catkin_ws/src/yolov7-ros/cmake/yolov7_ros-genmsg.cmake:3 (message):
  Invoking generate_messages() without having added any message or service
  file before.

  You should either add add_message_files() and/or add_service_files() calls
  or remove the invocation of generate_messages().
Call Stack (most recent call first):
  /opt/ros/noetic/share/genmsg/cmake/genmsg-extras.cmake:307 (include)
  CMakeLists.txt:76 (generate_messages)
```


## Link to Ticket
https://app.clickup.com/t/86c4bxkz5